### PR TITLE
Fixing multi.mset and a pre-existing unit test.

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -203,7 +203,12 @@ exports.hmget = function(mockInstance, hash) {
   }
 
   for (var i = 0; i < keys.length; i++) {
-    values.push(hash[keys[i]]);
+    if(hash[keys[i]]){
+      values.push(hash[keys[i]]);
+    }
+    else{
+      values.push(null);
+    }
   }
 
   mockInstance._callCallback(callback, null, values);

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -3,6 +3,7 @@
  * (c) 2013 Amsellem Yves <amsellem.yves@gmail.com>
  */
 exports.multi = function (mockInstance, RedisClient) {
+	var self = this;
 
 	var multiqueue = {
 		_queue: [],
@@ -18,7 +19,7 @@ exports.multi = function (mockInstance, RedisClient) {
 						}
 						cb.apply(null, arguments);
 					});
-					command.fn.apply(null, command.args);
+					command.fn.apply(self, command.args);
 				}
 			}
 
@@ -37,7 +38,7 @@ exports.multi = function (mockInstance, RedisClient) {
 	};
 
 	_fnAndNames(RedisClient.prototype, function(fn, fnName) {
-		if(fnName !== 'multi' || fnName !== 'MULTI') {
+		if(fnName !== 'multi' && fnName !== 'MULTI') {
 			multiqueue[fnName] = function() {
 				var args = Array.prototype.slice.call(arguments);
 				this._queue.push({


### PR DESCRIPTION
* transactions.js: `Multi.mset()` internally calls `.set()` but did not have scope access to it. Passing `self` instead of `null` fixes this.
* hash.js: Made `.hmget()` return `null` for absent keys rather than `undefined`.

@yamsellem 